### PR TITLE
Fix pair encoding and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # flask-code-nocodb
-cant post data to table  Not Found The requested URL was not found on the server.
+can't post data to table  Not Found The requested URL was not found on the server.
+
+## Configuration
+
+Set the NocoDB API key using the environment variable `NOCO_API_KEY` before
+running the application:
+
+```bash
+export NOCO_API_KEY=your_token_here
+```
+
+The Flask app reads this variable to authenticate with the NocoDB API.
+
+## Running the tests
+
+Install the test requirements and execute the suite with `pytest`:
+
+```bash
+pip install flask requests pytest
+pytest
+```

--- a/main (4).py
+++ b/main (4).py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify, request
 import requests
 import urllib.parse  # Untuk URL encoding
 import json
+import os
 
 app = Flask(__name__)
 
@@ -9,7 +10,7 @@ app = Flask(__name__)
 BASE_URL = "https://app.nocodb.com"
 TABLE_ID = "mgcg430t15let75"
 VIEW_ID = "vw03jsmpyql7yd43"
-NOCO_API_KEY = "8xJwzMGsZTlhm4i-PBEkvz7Z0CFdOssqSGgAr2rG"  # API token anda
+NOCO_API_KEY = os.getenv("NOCO_API_KEY", "")  # API token dari pemboleh ubah persekitaran
 
 HEADERS = {
     "xc-token": NOCO_API_KEY,
@@ -53,7 +54,7 @@ def update_sentimen_in_nocodb(pair, new_sentimen):
     print(f"[INFO] Proses kemas kini untuk pair='{pair}' kepada sentimen='{new_sentimen}'")
 
     # --- LANGKAH 1: Cari rekod ---
-    encoded_pair = urllib.parse.quote(pair)
+    encoded_pair = urllib.parse.quote(pair, safe='')
     search_url = f"{BASE_URL}/api/v2/tables/{TABLE_ID}/records?where=(pair,eq,{encoded_pair})&viewId={VIEW_ID}"
     print(f"[INFO] GET URL: {search_url}")
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,72 @@
+import importlib.util
+import json
+import requests
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("main_module", Path(__file__).resolve().parents[1] / "main (4).py")
+main = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(main)
+app = main.app
+update_sentimen_in_nocodb = main.update_sentimen_in_nocodb
+
+
+def test_index():
+    with app.test_client() as client:
+        resp = client.get('/')
+        assert resp.status_code == 200
+        text = resp.get_data(as_text=True)
+        assert "Server Flask" in text
+
+
+def test_update_sentimen(monkeypatch):
+    def mock_get(url, headers):
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"list": [{"Id": 1}]}
+        return Resp()
+
+    def mock_post(url, headers, json=None):
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {}
+        return Resp()
+
+    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(requests, 'post', mock_post)
+    with app.test_client() as client:
+        resp = client.post('/update-sentimen', json={"pair": "BTC/USDT", "sentimen": "Bullish"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "Berjaya"
+
+
+def test_url_encoding(monkeypatch):
+    captured = {}
+
+    def mock_get(url, headers):
+        captured['url'] = url
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {"list": [{"Id": 1}]}
+        return Resp()
+
+    def mock_post(url, headers, json=None):
+        class Resp:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {}
+        return Resp()
+
+    monkeypatch.setattr(requests, 'get', mock_get)
+    monkeypatch.setattr(requests, 'post', mock_post)
+
+    success, _ = update_sentimen_in_nocodb('BTC/USDT', 'Bearish')
+    assert success
+    assert '%2F' in captured['url']


### PR DESCRIPTION
## Summary
- document the API key environment variable and testing instructions
- use the NOCO_API_KEY environment variable in the Flask app
- URL-encode pair values fully
- add pytest-based tests for endpoints and encoding

## Testing
- `pip install requests flask pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68495f2f3a3c832fa9a8ed58d34e884e